### PR TITLE
pinentry popup issue for gpg 2.2+

### DIFF
--- a/src/Gpg.php
+++ b/src/Gpg.php
@@ -1466,6 +1466,7 @@ class Gpg
 
         $cmd[] = self::EXE_GPG;
         $cmd[] = '--batch';
+        $cmd[] = '--pinentry-mode=loopback';
         $cmd[] = '--yes';
         $cmd[] = '--always-trust';
         $cmd[] = '--output';


### PR DESCRIPTION
For decryption using gpg 2.2+ version, "--batch" switch did not work. To suppress pinentry popup from appearing, '--pinentry-mode=loopback' is a workaround.